### PR TITLE
Fix support for adding s3 of dbfs log file path to cluster creation

### DIFF
--- a/deploy-lambda/src/databricks_cdk/cluster.py
+++ b/deploy-lambda/src/databricks_cdk/cluster.py
@@ -48,7 +48,7 @@ class Cluster(BaseModel):
     driver_node_type_id: Optional[str] = None
     ssh_public_keys: List[str] = []
     custom_tags: Optional[dict] = None
-    cluster_log_conf: Optional[str] = None
+    cluster_log_conf: Optional[dict] = None
     init_scripts: List[dict] = []
     docker_image: Optional[DockerImage] = None
     spark_env_vars: Dict[str, str] = {}

--- a/typescript/src/resources/clusters/cluster.ts
+++ b/typescript/src/resources/clusters/cluster.ts
@@ -23,7 +23,7 @@ export interface ClusterStorageInfo {
     destination: string
 }
 
-export interface ClusterStorageInfoS3 extends ClusterStorageInfo{
+export interface ClusterStorageInfoS3 extends ClusterStorageInfo {
     region: string
     endpoint?: string
     enable_encryption?: boolean
@@ -44,6 +44,13 @@ export interface ClusterInitScriptInfoS3 {
     s3: ClusterStorageInfoS3
 }
 
+export interface ClusterLogConfDbfs {
+    dbfs: ClusterStorageInfo
+}
+
+export interface ClusterLogConfS3 {
+    s3: ClusterStorageInfoS3
+}
 export interface ClusterDockerBasicAuth {
     username: string
     password: string
@@ -66,7 +73,7 @@ export interface DatabricksCluster {
     driver_node_type_id?: string
     ssh_public_keys?: Array<string>
     custom_tags?: Record<string, unknown>
-    cluster_log_conf?: string
+    cluster_log_conf?: ClusterLogConfDbfs | ClusterLogConfS3
     init_scripts?: Array<ClusterInitScriptInfoDbfs | ClusterInitScriptInfoFile | ClusterInitScriptInfoS3>
     spark_env_vars?: Record<string, unknown>
     autotermination_minutes?: number


### PR DESCRIPTION
The current implementation is not correct. We should atleast be able to pass a dict to cluster_log_conf. Also CDK code needs to be changed to reflect this change. 