### PR TITLE
adjust types cluster and job to be compatible with instance pools

### DIFF
--- a/deploy-lambda/src/databricks_cdk/cluster.py
+++ b/deploy-lambda/src/databricks_cdk/cluster.py
@@ -15,9 +15,9 @@ class AutoScale(BaseModel):
 
 
 class AwsAttributes(BaseModel):
-    first_on_demand: int = 1
-    availability: str = "SPOT_WITH_FALLBACK"
-    zone_id: str
+    first_on_demand: Optional[int] = None
+    availability: Optional[str] = None
+    zone_id: Optional[str] = None
     instance_profile_arn: Optional[str] = None
     spot_bid_price_percent: Optional[int] = None
     ebs_volume_type: Optional[str] = None

--- a/deploy-lambda/src/databricks_cdk/job.py
+++ b/deploy-lambda/src/databricks_cdk/job.py
@@ -23,8 +23,8 @@ class AutoScale(BaseModel):
 
 
 class AwsAttributes(BaseModel):
-    first_on_demand: int = 1
-    availability: str = "SPOT_WITH_FALLBACK"
+    first_on_demand: Optional[int] = None
+    availability: Optional[str] = None
     zone_id: Optional[str] = None
     instance_profile_arn: Optional[str] = None
     spot_bid_price_percent: Optional[int] = None

--- a/typescript/src/resources/clusters/cluster.ts
+++ b/typescript/src/resources/clusters/cluster.ts
@@ -9,7 +9,7 @@ export interface ClusterAutoScale {
 export interface ClusterAwsAttributes {
     first_on_demand?: number
     availability?: string
-    zone_id: string
+    zone_id?: string
     instance_profile_arn?: string
     spot_bid_price_percent?: number
     ebs_volume_type?: string


### PR DESCRIPTION
There still some types that need to be set to optional to be compatible with instance_pools. I checked manual creation of cluster with instance_pool and job with instance_pool to make sure these fields really are optional. 