### PR TITLE
should be able to return generated token value

### DIFF
--- a/typescript/src/resources/tokens/token.ts
+++ b/typescript/src/resources/tokens/token.ts
@@ -25,6 +25,10 @@ export class Token extends CustomResource {
     }
 
     public tokenValue(): string {
+        /**
+         * Returns the secret value of the created token. Can only be returned
+         * when creating the token
+         */
         return this.getAttString("token_value");
     }
 }

--- a/typescript/src/resources/tokens/token.ts
+++ b/typescript/src/resources/tokens/token.ts
@@ -23,4 +23,8 @@ export class Token extends CustomResource {
             }
         });
     }
+
+    public tokenValue(): string {
+        return this.getAttString("token_value");
+    }
 }


### PR DESCRIPTION
Currently I am not able to get the generated token_value from the Construct. Looking at for example the credentials construct I see that there is a public function attached to return attribute string. Would this be required for token too? 