### PR TITLE
fix: remove pre-install scripts

### DIFF
--- a/examples/multi-stack/package.json
+++ b/examples/multi-stack/package.json
@@ -7,7 +7,6 @@
   },
   "scripts": {
     "lint": "eslint --max-warnings 0 'bin/**/*.ts'  'lib/**/*.ts'",
-    "preinstall": "mkdir -p ./node_modules && touch ./node_modules/.metadata_never_index",
     "cdk": "cdk",
     "synth": "cdk synth --context env='staging' --context tag='debug'",
     "deploy": "cdk deploy --context env='staging' --context tag='debug'"

--- a/examples/simple-workspace/package.json
+++ b/examples/simple-workspace/package.json
@@ -7,7 +7,6 @@
   },
   "scripts": {
     "lint": "eslint --max-warnings 0 'bin/**/*.ts'  'lib/**/*.ts'",
-    "preinstall": "mkdir -p ./node_modules && touch ./node_modules/.metadata_never_index",
     "cdk": "cdk",
     "synth": "cdk synth --context env='staging' --context tag='debug'",
     "deploy": "cdk deploy --context env='staging' --context tag='debug'"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -21,7 +21,6 @@
     },
     "scripts": {
         "lint": "eslint --max-warnings 0 'src/**/*.ts'",
-        "preinstall": "mkdir -p ./node_modules && touch ./node_modules/.metadata_never_index",
         "test": "jest"
     },
     "devDependencies": {


### PR DESCRIPTION
The old pre-install script is not platform agnostic, causing npm install to break on Windows machines.
Furthermore, in recent MacOS versions the `.metadata_never_index` file only works on volume roots, not in subfolders.