### PR TITLE
default name is generated by id, or can be provided in props

### DIFF
--- a/typescript/src/resources/deploy-lambda.ts
+++ b/typescript/src/resources/deploy-lambda.ts
@@ -46,6 +46,7 @@ export interface CustomDeployLambdaProps {
     readonly databricksPassParam?: string
     readonly databricksAccountParam?: string
     readonly lambdaCode?: aws_lambda.DockerImageCode
+    readonly lambdaName?: string
 }
 
 export abstract class IDatabricksDeployLambda extends Construct {
@@ -318,8 +319,8 @@ export class DatabricksDeployLambda extends IDatabricksDeployLambda {
             ]
         }));
 
-        this.lambda = new aws_lambda.DockerImageFunction(this, "Lambda", {
-            functionName: "DatabricksDeploy",
+        this.lambda = new aws_lambda.DockerImageFunction(this, `${id}Lambda`, {
+            functionName: this.props.lambdaName,
             code: dockerImageCode,
             timeout: Duration.seconds(300),
             role: this.lambdaRole,


### PR DESCRIPTION
Currently, fixed name is used. This is not nice. If you would like to deploy multiple databricks deploy lambdas on the same account you will get errors. Defined the behavior as follows:

1. If no lambdaName is provided in the props use DatabricksLambda construct id with Lambda appended to the name. 
2. If lambdaName is provided in props use this. 
