### PR TITLE
all overwrite of lambdaId for backwards compatibility

### DIFF
--- a/typescript/src/resources/deploy-lambda.ts
+++ b/typescript/src/resources/deploy-lambda.ts
@@ -48,6 +48,7 @@ export interface CustomDeployLambdaProps {
     readonly databricksAccountParam?: string
     readonly lambdaCode?: aws_lambda.DockerImageCode
     readonly lambdaName?: string
+    readonly lambdaId?: string
 }
 
 export abstract class IDatabricksDeployLambda extends Construct {
@@ -327,7 +328,8 @@ export class DatabricksDeployLambda extends IDatabricksDeployLambda {
             ]
         }));
 
-        this.lambda = new aws_lambda.DockerImageFunction(this, `${id}Lambda`, {
+        const lambdaId = this.props.lambdaId || `${id}Lambda`;
+        this.lambda = new aws_lambda.DockerImageFunction(this, lambdaId, {
             functionName: this.props.lambdaName,
             code: dockerImageCode,
             timeout: Duration.seconds(300),


### PR DESCRIPTION
Because of this change previous deployLambda will have a different serviceToken which is not allowed. 
Therefore to keep these stacks working there needs to be an option to overwrite the id of the created deployLambda.

In the future we need to adhere better to the cr setup advised by AWS
https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.custom_resources/README.html
Will raise a separate issue for this. 