### PR TITLE
replace password authentication with oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,11 @@ Deploy the stack to your AWS account:
 ```shell
 cdk deploy
 ```
-Note: The AWS SSM parameters `/databricks/deploy/user`, `/databricks/deploy/password`, and `/databricks/account-id` are required for the deployment to succeed.
+Note: The AWS SSM parameters `/databricks/deploy/client-id`, `/databricks/deploy/client-secret`, and `/databricks/account-id` are required for the deployment to succeed.
+
+- `/databricks/deploy/client-id` is the client-id of service principal that is account admin and workspace admin
+- `/databricks/deploy/client-secret` is the client-secret of service principal that is account admin and workspace admin
+- `/databricks/account-id` is the id of your databricks account
 
 See also the simple-workspace and multi-stack examples in [examples](examples)
 

--- a/aws-lambda/src/databricks_cdk/resources/clusters/cluster.py
+++ b/aws-lambda/src/databricks_cdk/resources/clusters/cluster.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 import requests
 from pydantic import BaseModel
 
-from databricks_cdk.utils import CnfResponse, get_auth, get_request, post_request
+from databricks_cdk.utils import CnfResponse, get_authorization_headers, get_request, post_request
 
 logger = logging.getLogger(__name__)
 
@@ -86,8 +86,11 @@ def get_cluster_by_name(cluster_name: str, workspace_url: str):
 def get_cluster_by_id(cluster_id: str, workspace_url: str) -> Optional[dict]:
     """Getting cluster based on name"""
     body = {"cluster_id": cluster_id}
-    auth = get_auth()
-    resp = requests.get(f"{get_cluster_url(workspace_url)}/get", json=body, headers={}, auth=auth)
+    resp = requests.get(
+        f"{get_cluster_url(workspace_url)}/get",
+        json=body,
+        headers=get_authorization_headers(),
+    )
     if resp.status_code == 400 and "does not exist" in resp.text:
         return None
     resp.raise_for_status()
@@ -100,7 +103,6 @@ def create_or_update_cluster(properties: ClusterProperties, physical_resource_id
     if physical_resource_id is not None:
         current = get_cluster_by_id(physical_resource_id, properties.workspace_url)
     if current is None:
-
         # Json data
         body = properties.cluster.dict()
         response = post_request(f"{get_cluster_url(properties.workspace_url)}/create", body=body)

--- a/aws-lambda/src/databricks_cdk/resources/jobs/job.py
+++ b/aws-lambda/src/databricks_cdk/resources/jobs/job.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Union
 import requests
 from pydantic import BaseModel
 
-from databricks_cdk.utils import CnfResponse, get_auth, post_request
+from databricks_cdk.utils import CnfResponse, get_authorization_headers, post_request
 
 logger = logging.getLogger(__name__)
 
@@ -175,8 +175,11 @@ def get_job_url(workspace_url: str):
 
 def get_job_by_id(job_id: str, workspace_url: str):
     body = {"job_id": job_id}
-    auth = get_auth()
-    resp = requests.get(f"{get_job_url(workspace_url)}/get", json=body, headers={}, auth=auth)
+    resp = requests.get(
+        f"{get_job_url(workspace_url)}/get",
+        json=body,
+        headers=get_authorization_headers(),
+    )
     if resp.status_code == 400 and "does not exist" in resp.text:
         return None
     resp.raise_for_status()

--- a/aws-lambda/src/databricks_cdk/resources/scim/user.py
+++ b/aws-lambda/src/databricks_cdk/resources/scim/user.py
@@ -1,10 +1,9 @@
 import logging
 from typing import Optional
 
-import requests
 from pydantic import BaseModel
 
-from databricks_cdk.utils import CnfResponse, get_auth, get_request, post_request
+from databricks_cdk.utils import CnfResponse, delete_request, get_request, post_request
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +40,6 @@ def create_or_update_user(properties: UserProperties) -> UserResponse:
 
     current = get_user_by_user_name(properties.user_name, properties.workspace_url)
     if current is None:
-
         # Json data
         body = {
             "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
@@ -58,16 +56,7 @@ def delete_user(properties: UserProperties, physical_resource_id: str) -> CnfRes
     """Deletes user at databricks"""
     current = get_user_by_user_name(properties.user_name, properties.workspace_url)
     if current is not None:
-        auth = get_auth()
-        if auth.username != properties.user_name:
-            resp = requests.delete(
-                f"{get_user_url(properties.workspace_url)}/{current['id']}",
-                headers={},
-                auth=auth,
-            )
-            resp.raise_for_status()
-        else:
-            logger.warning("Can't remove deploy user")
+        delete_request(f"{get_user_url(properties.workspace_url)}/{current['id']}")
     else:
         logger.warning("Already removed")
     return CnfResponse(physical_resource_id=physical_resource_id)

--- a/aws-lambda/src/databricks_cdk/resources/unity_catalog/schemas.py
+++ b/aws-lambda/src/databricks_cdk/resources/unity_catalog/schemas.py
@@ -2,7 +2,6 @@ import json
 import logging
 from typing import Dict, Optional
 
-import requests.exceptions
 from pydantic import BaseModel, Field
 
 from databricks_cdk.utils import CnfResponse, delete_request, get_request, patch_request, post_request

--- a/aws-lambda/tests/resources/tokens/test_token.py
+++ b/aws-lambda/tests/resources/tokens/test_token.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-import src.databricks_cdk.resources.tokens.token
 from src.databricks_cdk.resources.tokens.token import (
     TokenInfo,
     TokenProperties,
@@ -37,7 +36,12 @@ def test_create_token_not_exist(
 
     patched__create_token.return_value = {
         "token_value": "some_value",
-        "token_info": {"token_id": "some_id", "creation_time": 1234, "expiry_time": 1234, "comment": "some test token"},
+        "token_info": {
+            "token_id": "some_id",
+            "creation_time": 1234,
+            "expiry_time": 1234,
+            "comment": "some test token",
+        },
     }
     patched_get_existing_tokens.return_value = []
 
@@ -103,7 +107,14 @@ def test_create_token_already_exist(
 @patch("src.databricks_cdk.resources.tokens.token.get_request")
 def test_get_existing_token(patched_get_request):
     patched_get_request.return_value = {
-        "token_infos": [{"token_id": "test", "creation_time": 1, "expiry_time": 2, "comment": "test_comment"}]
+        "token_infos": [
+            {
+                "token_id": "test",
+                "creation_time": 1,
+                "expiry_time": 2,
+                "comment": "test_comment",
+            }
+        ]
     }
 
     token_list = get_existing_tokens(token_url="https://test.cloud.databricks.com/api/2.0/token")
@@ -118,7 +129,11 @@ def test_get_existing_token(patched_get_request):
 
 @patch("src.databricks_cdk.resources.tokens.token.post_request")
 def test__create_token(patched_post_request):
-    _create_token("https://test.cloud.databricks.com/api/2.0/token", comment="test_comment", lifetime_seconds=1)
+    _create_token(
+        "https://test.cloud.databricks.com/api/2.0/token",
+        comment="test_comment",
+        lifetime_seconds=1,
+    )
 
     assert patched_post_request.call_args.kwargs == {"body": {"comment": "test_comment", "lifetime_seconds": 1}}
 

--- a/aws-lambda/tests/test_utils.py
+++ b/aws-lambda/tests/test_utils.py
@@ -1,23 +1,33 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from databricks.sdk.core import Config
 from requests.exceptions import HTTPError
 from requests.models import Response
 
-from databricks_cdk.utils import _do_request, delete_request, get_request, patch_request, post_request, put_request
+from databricks_cdk.utils import (
+    _do_request,
+    delete_request,
+    get_account_client,
+    get_account_id,
+    get_client_id,
+    get_client_secret,
+    get_request,
+    get_workspace_client,
+    patch_request,
+    post_request,
+    put_request,
+)
 
 
-@patch("databricks_cdk.utils.get_auth")
+@patch("databricks_cdk.utils.get_authorization_headers")
 @patch("databricks_cdk.utils.request")
-def test__do_request_success(patched_requests, patched_get_auth):
+def test__do_request_success(patched_requests, patched_get_authorization_headers):
     # Prepare
     mock_response = MagicMock(spec=Response)
     mock_response.status_code = 200
     expected_response = {"result": "success"}
     mock_response.json.return_value = expected_response
-    mock_response
-
-    patched_get_auth.return_value = {}
 
     patched_requests.return_value = mock_response
     expected_url = "https://example.com"
@@ -29,15 +39,19 @@ def test__do_request_success(patched_requests, patched_get_auth):
 
     # Verify
     patched_requests.assert_called_once_with(
-        method="POST", url=expected_url, json=expected_body, params=expected_params, auth={}
+        method="POST",
+        url=expected_url,
+        json=expected_body,
+        params=expected_params,
+        headers=patched_get_authorization_headers.return_value,
     )
     mock_response.raise_for_status.assert_called_once()
     assert result == expected_response
 
 
-@patch("databricks_cdk.utils.get_auth")
+@patch("databricks_cdk.utils.get_authentication_config")
 @patch("databricks_cdk.utils.request")
-def test__do_request_http_error_retry(patched_requests, patched_get_auth):
+def test__do_request_http_error_retry(patched_requests, patched_get_authentication_config):
     # Prepare
     _do_request.retry.sleep = MagicMock()  # remove sleep in between
     expected_url = "https://example.com"
@@ -54,9 +68,9 @@ def test__do_request_http_error_retry(patched_requests, patched_get_auth):
     assert patched_requests.call_count == 5  # Retried 5 times
 
 
-@patch("databricks_cdk.utils.get_auth")
+@patch("databricks_cdk.utils.get_authorization_headers")
 @patch("databricks_cdk.utils.request")
-def test__do_request_http_error_no_retry(patched_requests, patched_get_auth):
+def test__do_request_http_error_no_retry(patched_requests, patched_get_authorization_headers):
     # Prepare
     expected_url = "https://example.com"
     mock_response = MagicMock(spec=Response)
@@ -72,8 +86,8 @@ def test__do_request_http_error_no_retry(patched_requests, patched_get_auth):
     assert patched_requests.call_count == 1  # Not retried
 
 
-@patch("databricks_cdk.utils.get_auth")
-def test__do_request_unsupported_method(patched_get_auth):
+@patch("databricks_cdk.utils.get_authorization_headers")
+def test__do_request_unsupported_method(patched_get_authorization_headers):
     # Prepare
     expected_url = "https://example.com"
 
@@ -125,3 +139,79 @@ def test_delete_request(patched__do_request):
     delete_request(expected_url, expected_body)
 
     patched__do_request.assert_called_once_with(method="DELETE", url=expected_url, body=expected_body, params=None)
+
+
+@patch("databricks_cdk.utils.get_param")
+def test_get_client_secret(patched_get_param):
+    from databricks_cdk.utils import CLIENT_SECRET_PARAM
+
+    result = get_client_secret()
+
+    assert result == patched_get_param.return_value
+    patched_get_param.assert_called_once_with(CLIENT_SECRET_PARAM, required=True)
+
+
+@patch("databricks_cdk.utils.get_param")
+def test_get_client_id(patched_get_param):
+    from databricks_cdk.utils import CLIENT_ID_PARAM
+
+    result = get_client_id()
+
+    assert result == patched_get_param.return_value
+    patched_get_param.assert_called_once_with(CLIENT_ID_PARAM, required=True)
+
+
+@patch("databricks_cdk.utils.get_param")
+def test_get_account_id(patched_get_param):
+    from databricks_cdk.utils import ACCOUNT_PARAM
+
+    result = get_account_id()
+
+    assert result == patched_get_param.return_value
+    patched_get_param.assert_called_once_with(ACCOUNT_PARAM, required=True)
+
+
+@patch("databricks_cdk.utils.get_client_secret")
+@patch("databricks_cdk.utils.get_client_id")
+@patch("databricks_cdk.utils.WorkspaceClient")
+def test_get_workspace_client(patched_workspace_client, patched_get_client_id, patched_get_client_secret):
+    result = get_workspace_client("https://example.com")
+
+    assert result == patched_workspace_client.return_value
+    patched_workspace_client.assert_called_once_with(
+        client_id=patched_get_client_id.return_value,
+        client_secret=patched_get_client_secret.return_value,
+        host="https://example.com",
+    )
+
+
+@patch("databricks_cdk.utils.WorkspaceClient")
+def test_get_workspace_client_with_config(
+    patched_workspace_client,
+):
+    config = MagicMock(spec=Config)
+    result = get_workspace_client("https://example.com", config=config)
+
+    assert result == patched_workspace_client.return_value
+    patched_workspace_client.assert_called_once_with(config=config)
+
+
+@patch("databricks_cdk.utils.get_client_secret")
+@patch("databricks_cdk.utils.get_client_id")
+@patch("databricks_cdk.utils.get_account_id")
+@patch("databricks_cdk.utils.AccountClient")
+def test_get_account_client(
+    patched_account_client,
+    patched_get_account_id,
+    patched_get_client_id,
+    patched_get_client_secret,
+):
+    result = get_account_client()
+
+    assert result == patched_account_client.return_value
+    patched_account_client.assert_called_once_with(
+        client_id=patched_get_client_id.return_value,
+        client_secret=patched_get_client_secret.return_value,
+        host="https://accounts.cloud.databricks.com",
+        account_id=patched_get_account_id.return_value,
+    )


### PR DESCRIPTION
Databricks is deprecating password authentication 10th of july (very fast indeed). 
We need to move to oauth asap.

- change account client and workspace client to use client-id and client-secret of a service principal
- use Config class of databricks to create authentication headers for all parts of code that still use normal requests (not the sdk client)

I think we should bump this as a patch version. I added a really specific exception that users need to change to service principal. If we do patch we know users will get a useful exception on time instead of authorization issues. 
